### PR TITLE
handle nested .tea directories when finding installed packages

### DIFF
--- a/modules/desktop/electron/libs/tea-dir.ts
+++ b/modules/desktop/electron/libs/tea-dir.ts
@@ -33,8 +33,8 @@ export async function getInstalledPackages(): Promise<InstalledPackage[]> {
 	log.info("recursively reading:", pkgsPath);
 	const folders = await deepReadDir({
 		dir: pkgsPath,
-		continueDeeper: (name: string) => !semver.valid(name),
-		filter: (name: string) => !!semver.valid(name)
+		continueDeeper: (name: string) => !semver.valid(name) && name !== ".tea",
+		filter: (name: string) => !!semver.valid(name) && name !== ".tea"
 	});
 
 	const bottles = folders


### PR DESCRIPTION
Closes #383 
Root cause of the issue was that brewkit has a nested `.tea` directory in it which caused parsing errors because the logic splits on the `.tea` sentinel in the path assuming it is only there once.