### PR TITLE
badge count relative to pkgs that needs update

### DIFF
--- a/modules/desktop/electron/libs/ipc.ts
+++ b/modules/desktop/electron/libs/ipc.ts
@@ -132,4 +132,13 @@ export default function initializeHandlers() {
 			return error.message;
 		}
 	});
+
+	ipcMain.handle("set-badge-count", async (_, { count }) => {
+		console.log("set badge count:", count);
+		if (count) {
+			app.dock.setBadge(count.toString());
+		} else {
+			app.dock.setBadge("");
+		}
+	});
 }

--- a/modules/desktop/electron/libs/push-notification.ts
+++ b/modules/desktop/electron/libs/push-notification.ts
@@ -11,7 +11,6 @@ import {
 } from "./tea-dir";
 import { app } from "electron";
 
-let pushCount = 0;
 export default function initialize(mainWindow: BrowserWindow) {
 	Pushy.listen();
 	// Register device for push notifications
@@ -32,8 +31,10 @@ export default function initialize(mainWindow: BrowserWindow) {
 		log.info("push data:", data);
 		// TODO: replace this with something
 		Pushy.alert(mainWindow, data?.message as string);
-		pushCount++;
-		if (pushCount) app.dock.setBadge(pushCount.toString());
+		const v = app.dock.getBadge();
+		if (!v) {
+			app.dock.setBadge("1");
+		}
 	});
 }
 

--- a/modules/desktop/src/libs/native-electron.ts
+++ b/modules/desktop/src/libs/native-electron.ts
@@ -219,3 +219,11 @@ export const isPackageInstalled = async (fullName: string, version?: string): Pr
 
 	return isInstalled;
 };
+
+export const setBadgeCount = async (count: number) => {
+	try {
+		await ipcRenderer.invoke("set-badge-count", { count });
+	} catch (error) {
+		log.error(error);
+	}
+};

--- a/modules/desktop/src/libs/native-mock.ts
+++ b/modules/desktop/src/libs/native-mock.ts
@@ -344,3 +344,7 @@ export const submitLogs = async () => {
 export const isPackageInstalled = async (_v?: string): Promise<boolean> => {
 	return true;
 };
+
+export const setBadgeCount = async (count: number) => {
+	console.log("set badge count", count);
+};

--- a/modules/desktop/src/libs/stores/pkgs.ts
+++ b/modules/desktop/src/libs/stores/pkgs.ts
@@ -7,7 +7,8 @@ import {
 	getDistPackages,
 	getInstalledPackages,
 	installPackage,
-	getPackageBottles
+	getPackageBottles,
+	setBadgeCount
 } from "@native";
 
 import { getReadme, getContributors, getRepoAsPackage } from "$libs/github";
@@ -34,6 +35,7 @@ export default function initPackagesStore() {
 					...props
 				};
 			}
+			setBadgeCountFromPkgs(pkgs);
 			return pkgs;
 		});
 	};
@@ -117,6 +119,8 @@ To read more about this package go to [${guiPkg.homepage}](${guiPkg.homepage}).
 					}
 					syncProgress.set(+((i + 1) / installedPkgs.length).toFixed(2));
 				}
+
+				setBadgeCountFromPkgs(guiPkgs);
 			} catch (error) {
 				log.error(error);
 			}
@@ -208,4 +212,13 @@ const withFakeLoader = (pkg: GUIPackage, callback: (progress: number) => void): 
 	}, ms);
 
 	return fakeTimer;
+};
+
+const setBadgeCountFromPkgs = (pkgs: GUIPackage[]) => {
+	try {
+		const needsUpdateCount = pkgs.filter((p) => p.state === PackageStates.NEEDS_UPDATE).length;
+		setBadgeCount(needsUpdateCount);
+	} catch (error) {
+		log.error(error);
+	}
 };


### PR DESCRIPTION
resolves #410

initial implementatin was to just count push notifications received, now its relative to packages that are on NEEDS_UPDATE state