### PR TITLE
install with `--env=false`

### DIFF
--- a/modules/desktop/electron/libs/cli.ts
+++ b/modules/desktop/electron/libs/cli.ts
@@ -15,7 +15,7 @@ export async function installPackage(full_name: string) {
 
 	if (!teaVersion) throw new Error("no tea");
 	log.info(`installing package ${full_name}`);
-	await asyncExec(`cd ${destinationDirectory} && ./tea -S +${full_name} true`);
+	await asyncExec(`cd ${destinationDirectory} && ./tea --env=false --sync +${full_name} true`);
 }
 
 export async function openTerminal(cmd: string) {


### PR DESCRIPTION
Prevents any local env being added