### PR TITLE
change package state detection

### DIFF
--- a/modules/desktop/electron/libs/cli.ts
+++ b/modules/desktop/electron/libs/cli.ts
@@ -107,9 +107,19 @@ function newInstallProgressNotifier(full_name: string, notifyMainWindow: MainWin
 			currentPackageNumber++;
 			const progress = (currentPackageNumber / numberOfPackages) * 100;
 			notifyMainWindow("install-progress", { full_name, progress });
+			notifyPackageInstalled(msg.pkg, notifyMainWindow);
 		}
 	};
 }
+
+const notifyPackageInstalled = (rawPkg: string, notifyMainWindow: MainWindowNotifier) => {
+	try {
+		const [full_name, version] = rawPkg.split("=");
+		notifyMainWindow("pkg-installed", { full_name, version });
+	} catch (err) {
+		log.error("failed to notify package installed", err);
+	}
+};
 
 export async function openPackageEntrypointInTerminal(pkg: string) {
 	let sh = `${cliBinPath} --sync --env=false +${pkg} `;

--- a/modules/desktop/src/components/package-install-button/package-install-button.svelte
+++ b/modules/desktop/src/components/package-install-button/package-install-button.svelte
@@ -30,7 +30,6 @@
 		[PackageStates.NEEDS_UPDATE]: "update-badge",
 		[PackageStates.UPDATING]: "update-badge",
 		[PackageStates.INSTALLED]: "installed-badge",
-		[PackageStates.UNINSTALLED]: ""
 	};
 
 	const hasVersionSelectorDropdown = !!$$slots.selector;

--- a/modules/desktop/src/libs/packages/pkg-utils.ts
+++ b/modules/desktop/src/libs/packages/pkg-utils.ts
@@ -37,3 +37,11 @@ export const findRecentInstalledVersion = (pkg: GUIPackage) => {
 	// this assumes that the versions are already sorted
 	return pkg.installed_versions?.[0];
 };
+
+export const isInstalling = (pkg: GUIPackage) => {
+	return (
+		pkg.install_progress_percentage &&
+		pkg.install_progress_percentage > 0 &&
+		pkg.install_progress_percentage < 100
+	);
+};

--- a/modules/desktop/src/libs/types.ts
+++ b/modules/desktop/src/libs/types.ts
@@ -9,7 +9,6 @@ export enum PackageStates {
 	AVAILABLE = "AVAILABLE",
 	INSTALLED = "INSTALLED",
 	INSTALLING = "INSTALLING",
-	UNINSTALLED = "UNINSTALLED",
 	NEEDS_UPDATE = "NEEDS_UPDATE",
 	UPDATING = "UPDATING"
 }
@@ -24,6 +23,7 @@ export type GUIPackage = Package & {
 	installed_versions?: string[];
 	synced?: boolean;
 	install_progress_percentage?: number;
+	isUninstalling?: boolean;
 	cached_image_url?: string;
 };
 


### PR DESCRIPTION
We had a few issues with package state getting out of sync.  I centralized as many updates as possible to inside of the store to avoid race conditions and duplicated state setting logic all over the place.

This pr fixes a few issues:
- user manually deletes a package and UI never detects it and also won't allow package to be reinstalled
- user installs package with dependencies, dependencies do not show up in UI until app is restarted
- user installs an old version of package instead of latest, package is in the INSTALLED state until the app is restarted.