### PR TITLE
30 min  package refresh

### DIFF
--- a/electron/libs/auto-updater.ts
+++ b/electron/libs/auto-updater.ts
@@ -13,7 +13,7 @@ type AutoUpdateStatus = {
 autoUpdater.logger = log;
 
 let mainWindowNotifier: MainWindowNotifier | null = null;
-let initialed = false;
+let initialized = false;
 let isUpdating = false;
 
 // keep the last status to resend to the window when it's opened becuase the store is destroyed when the window is closed
@@ -26,8 +26,8 @@ export function checkUpdater(notifier: MainWindowNotifier): AppUpdater {
     mainWindowNotifier = notifier;
     checkForUpdates();
 
-    if (!initialed) {
-      initialed = true;
+    if (!initialized) {
+      initialized = true;
 
       setInterval(() => {
         checkForUpdates();

--- a/electron/libs/auto-updater.ts
+++ b/electron/libs/auto-updater.ts
@@ -13,7 +13,7 @@ type AutoUpdateStatus = {
 autoUpdater.logger = log;
 
 let mainWindowNotifier: MainWindowNotifier | null = null;
-let initalized = false;
+let initialed = false;
 let isUpdating = false;
 
 // keep the last status to resend to the window when it's opened becuase the store is destroyed when the window is closed
@@ -26,8 +26,8 @@ export function checkUpdater(notifier: MainWindowNotifier): AppUpdater {
     mainWindowNotifier = notifier;
     checkForUpdates();
 
-    if (!initalized) {
-      initalized = true;
+    if (!initialed) {
+      initialed = true;
 
       setInterval(() => {
         checkForUpdates();

--- a/svelte/src/app.d.ts
+++ b/svelte/src/app.d.ts
@@ -8,7 +8,7 @@ declare namespace App {
   // interface Platform {}
 }
 
-// Declare custom event handlers here to make typscript happy.
+// Declare custom event handlers here to make typescript happy.
 declare namespace svelte.JSX {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface HTMLAttributes<T> {

--- a/svelte/src/libs/stores/pkgs.ts
+++ b/svelte/src/libs/stores/pkgs.ts
@@ -8,7 +8,6 @@ import {
   getInstalledPackages,
   installPackage,
   deletePackage,
-  setBadgeCount,
   loadPackageCache,
   writePackageCache,
   syncPantry,
@@ -21,7 +20,7 @@ import {
   getPantryDetails
 } from "@native";
 
-import { getReadme, getContributors, getRepoAsPackage, trimGithubSlug } from "$libs/repo";
+import { getReadme, getContributors, getRepoAsPackage } from "$libs/repo";
 import { trackInstall, trackInstallFailed } from "$libs/analytics";
 import {
   addInstalledVersion,
@@ -62,7 +61,7 @@ const updateAllPackages = (guiPkgs: GUIPackage[]) => {
       const oldPkg = pkgs.packages[pkg.full_name];
       pkgs.packages[pkg.full_name] = { ...oldPkg, ...pkg };
     });
-    setBadgeCountFromPkgs(pkgs);
+
     return pkgs;
   });
 };
@@ -89,8 +88,6 @@ const updatePackage = (full_name: string, props: Partial<GUIPackage>, newVersion
 
       updatedPkg.state = getPackageState(updatedPkg);
       pkgs.packages[full_name] = updatedPkg;
-
-      setBadgeCountFromPkgs(pkgs);
     }
     return pkgs;
   });
@@ -392,17 +389,6 @@ export const withFakeLoader = (
   }, ms);
 
   return fakeTimer;
-};
-
-const setBadgeCountFromPkgs = (pkgs: Packages) => {
-  try {
-    const needsUpdateCount = Object.values(pkgs.packages).filter(
-      (p) => p.state === PackageStates.NEEDS_UPDATE
-    ).length;
-    setBadgeCount(needsUpdateCount);
-  } catch (error) {
-    log.error(error);
-  }
 };
 
 const resetPackageDisplayState = (pkg: GUIPackage) => {

--- a/svelte/src/libs/stores/pkgs.ts
+++ b/svelte/src/libs/stores/pkgs.ts
@@ -371,17 +371,6 @@ listenToChannel("pkg-modified", ({ full_name }: any) => {
   refreshSinglePackage(full_name);
 });
 
-const setBadgeCountFromPkgs = (pkgs: Packages) => {
-  try {
-    const needsUpdateCount = Object.values(pkgs.packages).filter(
-      (p) => p.state === PackageStates.NEEDS_UPDATE
-    ).length;
-    setBadgeCount(needsUpdateCount);
-  } catch (error) {
-    log.error(error);
-  }
-};
-
 // This is only used for uninstall now
 export const withFakeLoader = (
   pkg: GUIPackage,
@@ -403,6 +392,17 @@ export const withFakeLoader = (
   }, ms);
 
   return fakeTimer;
+};
+
+const setBadgeCountFromPkgs = (pkgs: Packages) => {
+  try {
+    const needsUpdateCount = Object.values(pkgs.packages).filter(
+      (p) => p.state === PackageStates.NEEDS_UPDATE
+    ).length;
+    setBadgeCount(needsUpdateCount);
+  } catch (error) {
+    log.error(error);
+  }
 };
 
 const resetPackageDisplayState = (pkg: GUIPackage) => {

--- a/svelte/src/libs/stores/pkgs.ts
+++ b/svelte/src/libs/stores/pkgs.ts
@@ -166,6 +166,10 @@ const init = async function () {
     await refreshPackages();
     await monitorTeaDir();
     initialized = true;
+
+    setInterval(async () => {
+      await refreshPackages();
+    }, 1000 * 60 * 30);
   }
   log.info("packages store: initialized!");
 };

--- a/svelte/src/libs/stores/pkgs.ts
+++ b/svelte/src/libs/stores/pkgs.ts
@@ -89,8 +89,9 @@ const updatePackage = (full_name: string, props: Partial<GUIPackage>, newVersion
 
       updatedPkg.state = getPackageState(updatedPkg);
       pkgs.packages[full_name] = updatedPkg;
+      setBadgeCountFromPkgs(pkgs);
     }
-    setBadgeCountFromPkgs(pkgs);
+
     return pkgs;
   });
 };
@@ -152,17 +153,6 @@ To read more about this package go to [${guiPkg.homepage || guiPkg.github_url}](
   }
 
   updatePackage(guiPkg.full_name!, updatedPackage);
-};
-
-const setBadgeCountFromPkgs = (pkgs: Packages) => {
-  try {
-    const needsUpdateCount = Object.values(pkgs.packages).filter(
-      (p) => p.state === PackageStates.NEEDS_UPDATE
-    ).length;
-    setBadgeCount(needsUpdateCount);
-  } catch (error) {
-    log.error(error);
-  }
 };
 
 const init = async function () {
@@ -380,6 +370,17 @@ listenToChannel("pkg-modified", ({ full_name }: any) => {
   }
   refreshSinglePackage(full_name);
 });
+
+const setBadgeCountFromPkgs = (pkgs: Packages) => {
+  try {
+    const needsUpdateCount = Object.values(pkgs.packages).filter(
+      (p) => p.state === PackageStates.NEEDS_UPDATE
+    ).length;
+    setBadgeCount(needsUpdateCount);
+  } catch (error) {
+    log.error(error);
+  }
+};
 
 // This is only used for uninstall now
 export const withFakeLoader = (

--- a/svelte/src/libs/stores/pkgs.ts
+++ b/svelte/src/libs/stores/pkgs.ts
@@ -17,7 +17,8 @@ import {
   monitorTeaDir,
   stopMonitoringTeaDir,
   isDev,
-  getPantryDetails
+  getPantryDetails,
+  setBadgeCount
 } from "@native";
 
 import { getReadme, getContributors, getRepoAsPackage } from "$libs/repo";
@@ -61,7 +62,7 @@ const updateAllPackages = (guiPkgs: GUIPackage[]) => {
       const oldPkg = pkgs.packages[pkg.full_name];
       pkgs.packages[pkg.full_name] = { ...oldPkg, ...pkg };
     });
-
+    setBadgeCountFromPkgs(pkgs);
     return pkgs;
   });
 };
@@ -89,6 +90,7 @@ const updatePackage = (full_name: string, props: Partial<GUIPackage>, newVersion
       updatedPkg.state = getPackageState(updatedPkg);
       pkgs.packages[full_name] = updatedPkg;
     }
+    setBadgeCountFromPkgs(pkgs);
     return pkgs;
   });
 };
@@ -150,6 +152,17 @@ To read more about this package go to [${guiPkg.homepage || guiPkg.github_url}](
   }
 
   updatePackage(guiPkg.full_name!, updatedPackage);
+};
+
+const setBadgeCountFromPkgs = (pkgs: Packages) => {
+  try {
+    const needsUpdateCount = Object.values(pkgs.packages).filter(
+      (p) => p.state === PackageStates.NEEDS_UPDATE
+    ).length;
+    setBadgeCount(needsUpdateCount);
+  } catch (error) {
+    log.error(error);
+  }
 };
 
 const init = async function () {


### PR DESCRIPTION
As far as I can tell, the gui only checks the update status on packages when the gui is initialized.  So you have to reset the gui in order to see the needed updates.  I can reduce the timeframe, but doing this at least once a day would make sense to me