### PR TITLE
fix release gha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
       debug: 0
     secrets: inherit
   upload:
+    permissions:
+      contents: write
     needs: [build_desktop]
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
The release GHA needs explicit permissions to create a GH release.  This should fix it.